### PR TITLE
Fixes build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-27.0.2
+    - build-tools-27.0.3
     - android-27
     - extra-google-m2repository
     - extra-android-m2repository

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/chahine/pageindicator.svg?branch=master)](https://travis-ci.org/chahine/pageindicator)
+
 # Page Indicator
 
 An Instagram like page indicator compatible with [RecyclerView](https://developer.android.com/reference/android/support/v7/widget/RecyclerView.html) and [ViewPager](https://developer.android.com/reference/android/support/v4/view/ViewPager.html).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,11 +19,12 @@ android {
   }
 
   buildTypes {
-    debug {
+    release {
       multiDexEnabled false
       minifyEnabled true
       shrinkResources true
       zipAlignEnabled true
+      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,11 +2,9 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
-androidExtensions { experimental = true }
 
 android {
   compileSdkVersion rootProject.compileSdkVersion
-  buildToolsVersion rootProject.buildToolsVersion
 
   defaultConfig {
     applicationId 'com.chahinem.pageindicator.sample'

--- a/app/src/main/java/com/chahinem/pageindicator/sample/MyAdapter.kt
+++ b/app/src/main/java/com/chahinem/pageindicator/sample/MyAdapter.kt
@@ -20,8 +20,8 @@ class MyAdapter(private val picasso: Picasso) : RecyclerView.Adapter<MyViewHolde
           .from(parent.context)
           .inflate(R.layout.item_card, parent, false))
 
-  override fun onBindViewHolder(holder: MyViewHolder?, position: Int) {
-    holder?.bind(picasso, items[holder.adapterPosition])
+  override fun onBindViewHolder(holder: MyViewHolder, position: Int) {
+    holder.bind(picasso, items[holder.adapterPosition])
   }
 
   fun swapData(data: Iterable<MyItem>?) {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,14 +3,13 @@ ext {
   minSdkVersion = 14
   compileSdkVersion = 27
   targetSdkVersion = 27
-  buildToolsVersion = '27.0.2'
-  gradleVersion = '3.0.1'
-  kotlinVersion = '1.2.21'
+  gradleVersion = '3.1.1'
+  kotlinVersion = '1.2.40'
 
-  supportLibraryVersion = '27.0.2'
+  supportLibraryVersion = '27.1.1'
 
   // Kotlin
-  kotlinStdlib = 'org.jetbrains.kotlin:kotlin-stdlib-jre8:' + kotlinVersion
+  kotlinStdlib = 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:' + kotlinVersion
 
   def groupId = 'com.android.support'
   appcompatV7 = groupId + ':appcompat-v7:' + supportLibraryVersion
@@ -18,8 +17,7 @@ ext {
   design = groupId + ':design:' + supportLibraryVersion
   recyclerviewV7 = groupId + ':recyclerview-v7:' + supportLibraryVersion
   supportAnnotations = groupId + ':support-annotations:' + supportLibraryVersion
-  supportV4 = groupId + ':support-v4:' + supportLibraryVersion
-  constraintLayout = groupId + '.constraint:constraint-layout:1.1.0-beta3'
+  constraintLayout = groupId + '.constraint:constraint-layout:1.1.0'
 
 
   picasso = 'com.squareup.picasso:picasso:2.6.0-SNAPSHOT'
@@ -29,7 +27,6 @@ ext {
                  design,
                  recyclerviewV7,
                  supportAnnotations,
-                 supportV4,
                  constraintLayout]
 
   junit = 'junit:junit:4.12'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/pageindicator/build.gradle
+++ b/pageindicator/build.gradle
@@ -6,11 +6,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 group = 'com.github.chahinem'
 version = '0.2.5'
 
-androidExtensions { experimental = true }
-
 android {
   compileSdkVersion rootProject.compileSdkVersion
-  buildToolsVersion rootProject.buildToolsVersion
 
   defaultConfig {
     minSdkVersion rootProject.minSdkVersion
@@ -32,9 +29,8 @@ android {
 }
 
 dependencies {
-  implementation rootProject.kotlinStdlib
-  implementation rootProject.recyclerviewV7
-  implementation rootProject.supportV4
-
+  compileOnly rootProject.kotlinStdlib
+  compileOnly rootProject.recyclerviewV7
   testImplementation rootProject.junit
+  testImplementation rootProject.kotlinStdlib
 }


### PR DESCRIPTION
I had a problem using this package, the error was `Cannot resolve "support-v4"`, since the project has a dependency to `appcompat-v7` which itself includes the `support-v4` there's no need to add it again.

This pull also changes the library dependencies from `implementation` to `compileOnly`